### PR TITLE
Add support for a .polyrc file

### DIFF
--- a/poly.py
+++ b/poly.py
@@ -300,6 +300,8 @@ def run_cli(stdscr):
     inp = ""
     suggestions = []
     sugg_idx = 0
+    polyrc_chars = read_polyrc()
+    polyrc_index = 0
     while True:
         h, w = stdscr.getmaxyx()
         stdscr.erase()
@@ -333,7 +335,10 @@ def run_cli(stdscr):
         stdscr.move(h - 1, VERTICAL_COL + 4 + len(cwd_disp) + len(inp))
         stdscr.refresh()
         try:
-            ch = stdscr.get_wch()
+            if polyrc_index >= len(polyrc_chars):
+                ch = stdscr.get_wch()
+            else:
+                ch = polyrc_chars[polyrc_index]
         except curses.error:
             time.sleep(0.05)
             continue
@@ -443,16 +448,25 @@ def run_cli(stdscr):
             continue
         if isinstance(ch, str) and ch.isprintable():
             inp += ch
+            polyrc_index += 1
 
-
+def read_polyrc():
+    try:
+        chars = []
+        with open(os.path.expanduser("~/.polyrc"), "r") as rcfile:
+            for line in rcfile.readlines():
+                for char in list(line):
+                    chars.append(char)
+        return chars
+    except FileNotFoundError:
+        return []
 
 def main():
     try:
         curses.wrapper(run_cli)
+        print(read_polyrc())
     except KeyboardInterrupt:
         pass
-
-
 
 if __name__ == "__main__":
     main()

--- a/poly.py
+++ b/poly.py
@@ -394,6 +394,8 @@ def run_cli(stdscr):
             inp = ""
             continue
         if ch in ("\n", "\r"):
+            polyrc_index += 1
+
             line = inp
             inp = ""
             if mode != 'poly':
@@ -486,7 +488,6 @@ def read_polyrc():
 def main():
     try:
         curses.wrapper(run_cli)
-        print(read_polyrc())
     except KeyboardInterrupt:
         pass
 


### PR DESCRIPTION
This commit adds support for a *run-commands* file (located at `~/.polyrc` or `%USERPROFILE%\.polyrc` based on platform). It auto-loads the file on startup and runs all commands in succession.

Example:
```poly
tab mode lnx
echo "Hello, world!"
```

This will put you in Linux mode and print `Hello, world!` to the Poly terminal.