### PR TITLE
Make polyrc not echo commands to the buffer and add power management commands

### DIFF
--- a/poly.py
+++ b/poly.py
@@ -589,6 +589,18 @@ def run_cli(stdscr):
                 except ValueError:
                     tabs[current].add("Usage: download <url> \"<filename>\"")
                 continue
+            if lc == "shutdown" and not rest:
+                if os.name == "nt":
+                    subprocess.run(["shutdown", "/s", "/t", "0"])
+                else:
+                    subprocess.run(["shutdown", "now"])
+                continue
+            if lc == "reboot" and not rest:
+                if os.name == "nt":
+                    subprocess.run(["shutdown", "/r", "/t", "0"])
+                else:
+                    subprocess.run(["reboot"])
+                continue
             tabs[current].add(f"Unknown: {cmd}")
             continue
         if ch in (curses.KEY_BACKSPACE, "\b", "\x7f"):


### PR DESCRIPTION
This commit ensures that, when reading the `.polyrc` file, commands that are run are not returned inside the buffer, unlike before this commit.