### PR TITLE
Fix parroting command to output on non-poly modes

### DIFF
--- a/poly.py
+++ b/poly.py
@@ -709,13 +709,13 @@ def run_cli(stdscr):
             inp = ""
             if line.strip():
                 tabs[current].history.append(line)
+            if not reading_polyrc:
+                tabs[current].add(f"> {line}")
             if mode != 'poly':
                 tabs[current].write_input(line)
                 continue
             if not line.strip():
                 continue
-            if not reading_polyrc:
-                tabs[current].add(f"> {line}")
             if mode != 'poly':
                 tabs[current].write_input(line)
                 continue


### PR DESCRIPTION
This commit ensures that commit 7953368ed80bcccc70674f876beffcd731141f8d's changes will work on `win`, `pws`, `lnx`, and any/all other tab modes.