### PR TITLE
Add Linux install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Made for Windows 11 and Linux.
 ## Installation
 You can download Poly [here](https://ravendevteam.org/software/poly).
 
-To compile from source, make sure you have Python 3.12.4, and Nuitka. Install the necessary dependencies from `requirements.txt`, then run `build.bat`.
+To compile from source, make sure you have Python >=3.12.4 and Nuitka. Install the necessary dependencies from `requirements.txt`, then run the `build.bat` or `build.sh` script based on your platform.
 
 ## Features & Usage
 - **.polyrc:** Create a .polyrc file in your home directory to define initial commands to execute.

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+echo "Beginning Poly build process..."
+if ! [ -f /usr/bin/nuitka ]; then
+    echo "Nuitka was not found on your system. Continue anyways? (y/N)"
+    read -n1 nuitka_continue
+    if [ "$nuitka_continue" != "y" ]; then
+        exit
+    fi
+fi
+
+nuitka --onefile --standalone --remove-output --enable-plugin=tk-inter --windows-icon-from-ico=ICON.ico --output-dir=dist poly.py
+
+mv dist/poly.bin dist/poly
+
+echo "Build complete!"


### PR DESCRIPTION
This commit adds the `build.sh` shell script, allowing Linux users to simply compile Poly from source. It also edits the README to show instructions for using the `sh` file.