### PR TITLE
Run command hotfix

### DIFF
--- a/test.poly
+++ b/test.poly
@@ -1,2 +1,0 @@
-run notepad.exe
-echo test


### PR DESCRIPTION
This commit fixes a critical bug in the run command that crashes Poly when running anything other than `.poly` scripts.