### PR TITLE
Fix: Poly.py not passing current tab to plugins.

### DIFF
--- a/poly.py
+++ b/poly.py
@@ -725,7 +725,7 @@ def handle_single_command(cmd_line, tabs, current):
     if lc in ALIASES.keys():
         lc = ALIASES[lc]
     if lc in CUSTOM_COMMANDS.keys():
-        CUSTOM_COMMANDS[lc](CUSTOM_COMMANDS[f"__{lc}_args"], rest)
+        CUSTOM_COMMANDS[lc](tabs[current], rest)
         return current, False
     if lc in ("exit", "quit"):
         return current, True


### PR DESCRIPTION
# Fix: Ensure Custom Commands Operate on the Correct Active Tab

## Description

This pull request addresses a bug in the command execution logic that caused custom commands (from plugins) to always execute in the context of the latest created tab, rather than the currently active one. 

## The Problem

Previously, custom commands were invoked using their pre-registered arguments:

```python
# Old implementation in poly.py
CUSTOM_COMMANDS[lc](CUSTOM_COMMANDS[f"__{lc}_args"], rest)
````

This created a critical issue in a multi-tab environment:

1.  The application starts, creating Tab A.
2.  Plugins are loaded, and their commands store a reference to Tab A.
3.  Uses plugin and plugin prints on Tab A
4.  The user creates a new tab, Tab B, and switches to it.
5.  The user runs a custom command in the active Tab B.
6.  Plugin prints on Tab B
7.  The user switches back to Tab A and runs custom command.

<!-- end list -->

  * **Expected behavior:** The command's output should appear in Tab A.
  * **Actual behavior:** The command would receive the latest created tab as if you are in that tab, and all its output would be incorrectly rendered in the latest created, now-inactive tab. This broke the multi-tab functionality entirely.


## The Solution

This PR fixes the issue by changing the command invocation to pass the currently active tab object directly:

```python
# New implementation in poly.py
CUSTOM_COMMANDS[lc](tabs[current], rest)
```

By passing `tabs[current]`, we ensure that the command function always receives the correct, active context to operate in. This resolves the multi-tab bug and makes the application behave as expected.

## Impact on Plugins

This is a **breaking change** for the existing plugin API. Plugin command functions must be updated to accept the tab object directly, rather than a list of arguments.

Example of required plugin change:

```python
# Old plugin function signature
def my_command(args, rest):
    tab = args[0]
    # ...

# New, required plugin function signature
def my_command(tab, rest):
    # ...
```