### PR TITLE
Add an index argument to last

### DIFF
--- a/poly.py
+++ b/poly.py
@@ -928,7 +928,7 @@ def handle_single_command(cmd_line, tabs, current):
         else:
             try:
                 index = int(rest)
-                selected_cmd = tabs[current].history[-(index + 2)] # +2 and not +1 to ignore the entry of the current cmd
+                selected_cmd = tabs[current].history[-(index + 2)]
             except Exception:
                 tabs[current].add("Usage: last <index>\nindex must be less than the length of the history")
                 return current, False


### PR DESCRIPTION
This PR adds the ability to run a command in the history based on an index using the `last` command. Example:
```
> echo Hello, world!
Hello, world!
> echo Goodbye, world!
Goodbye, world!
> last 0
> echo Goodbye, world!
Goodbye, world!
> last 2
> echo Hello, world!
Hello, world!
> last 0
> last 2
> echo Goodbye, world!
Goodbye, world!
```

`last 0` runs the last command,
`last 1` runs the command before the last,
etc.