### PR TITLE
Check if tab mode is poly before appending to history

### DIFF
--- a/poly.py
+++ b/poly.py
@@ -1223,7 +1223,7 @@ def run_cli(stdscr):
             line = inp
             inp = ""
             cursor_pos = 0
-            if line.strip():
+            if line.strip() and tabs[current].mode == 'poly':
                 tabs[current].history.append(line)
             if not reading_script:
                 tabs[current].add(f"> {line}")


### PR DESCRIPTION
This pull request updates the `history` and `last` commands to only work with commands typed in poly mode