### PR TITLE
Fix last command not preserving colors

### DIFF
--- a/poly.py
+++ b/poly.py
@@ -916,6 +916,12 @@ def handle_single_command(cmd_line, tabs, current):
             stdscr = curses.initscr()
             curses.start_color()
             curses.cbreak()
+            curses.use_default_colors()
+            curses.init_pair(1, curses.COLOR_WHITE, -1)
+            if getattr(curses, 'COLORS', 0) >= 16:
+                curses.init_pair(2, 8, -1)
+            else:
+                curses.init_pair(2, curses.COLOR_WHITE, -1)
             curses.noecho()
             stdscr.keypad(True)
 


### PR DESCRIPTION
This pull request adds the missing color pair initialization in the `last` command after the curses screen reinitialization